### PR TITLE
Minting updates

### DIFF
--- a/backend-stacks/Clarinet.toml
+++ b/backend-stacks/Clarinet.toml
@@ -15,6 +15,10 @@ contract_id = 'SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait'
 path = 'contracts/external/commission-free.clar'
 clarity_version = 1
 
+[contracts.ryder-mint-free]
+path = 'contracts/external/ryder-mint-free.clar'
+clarity_version = 1
+
 [contracts.ryder-mint]
 path = 'contracts/ryder-mint.clar'
 clarity_version = 1

--- a/backend-stacks/contracts/external/ryder-mint-free.clar
+++ b/backend-stacks/contracts/external/ryder-mint-free.clar
@@ -1,0 +1,3 @@
+
+(define-public (mint-free (recipient principal))
+    (contract-call? .ryder-nft mint recipient))

--- a/backend-stacks/contracts/ryder-mint.clar
+++ b/backend-stacks/contracts/ryder-mint.clar
@@ -69,7 +69,7 @@
 
 ;; admin functions
 (define-read-only (check-is-admin)
-  (ok (asserts! (default-to false (map-get? admins tx-sender)) err-unauthorized)))
+  (ok (asserts! (default-to false (map-get? admins contract-caller)) err-unauthorized)))
 
 (define-public (set-launched (launched bool))
   (begin

--- a/backend-stacks/contracts/ryder-mint.clar
+++ b/backend-stacks/contracts/ryder-mint.clar
@@ -1,7 +1,6 @@
 (define-constant MAX-MINT-PER-PRINCIPAL u2)
 
 (define-constant err-unauthorized (err u403))
-(define-constant err-already-done (err u505))
 (define-constant err-not-launched (err u506))
 (define-constant err-max-mint-reached (err u507))
 
@@ -26,7 +25,7 @@
     (asserts! (or (< sender-mint-count MAX-MINT-PER-PRINCIPAL) public-mint-started) err-max-mint-reached)
     (map-set mint-count tx-sender (+ sender-mint-count u1))
     (try! (stx-transfer? (var-get price-in-ustx) tx-sender (var-get payment-recipient)))
-    (contract-call? .ryder-nft mint)))
+    (contract-call? .ryder-nft mint tx-sender)))
 
 (define-public (claim)
   (mint))

--- a/backend-stacks/contracts/ryder-nft.clar
+++ b/backend-stacks/contracts/ryder-nft.clar
@@ -35,7 +35,7 @@
 (define-constant err-fatale (err u999))
 
 ;; Variables
-(define-data-var token-uri (string-ascii 80) "ipfs://ipfs/Qm../{id}.json")
+(define-data-var token-uri (string-ascii 256) "ipfs://ipfs/Qm../{id}.json")
 (define-data-var token-id-nonce uint u1)
 (define-data-var mint-limit uint u2000)
 (define-data-var metadata-fluid bool true)
@@ -122,7 +122,7 @@
 (define-read-only (check-is-admin)
   (ok (asserts! (default-to false (map-get? admins contract-caller)) err-unauthorized)))
 
-(define-public (set-token-uri (new-uri (string-ascii 80)))
+(define-public (set-token-uri (new-uri (string-ascii 256)))
   (begin
     (try! (check-is-admin))
     (asserts! (var-get metadata-fluid) err-unauthorized)

--- a/backend-stacks/tests/clients/ryder-mint-client.ts
+++ b/backend-stacks/tests/clients/ryder-mint-client.ts
@@ -69,7 +69,7 @@ export function dickson5003Permut(
 
 export function enabledPublicMint(chain: Chain, deployer: Account) {
   let block = chain.mineBlock([
-    setMinter(`'${deployer.address}.ryder-mint`, deployer.address),
+    setMinter(`'${deployer.address}.ryder-mint`, true, deployer.address),
     setLaunched(true, deployer.address),
     setPublicMint(true, deployer.address),
   ]);

--- a/backend-stacks/tests/clients/ryder-nft-client.ts
+++ b/backend-stacks/tests/clients/ryder-nft-client.ts
@@ -71,8 +71,8 @@ export function setAdmin(newAdmin: string, userAddress: string) {
   return Tx.contractCall("ryder-nft", "set-admin", [newAdmin], userAddress);
 }
 
-export function setMinter(newMinter: string, userAddress: string) {
-  return Tx.contractCall("ryder-nft", "set-minter", [newMinter], userAddress);
+export function setMinter(newMinter: string, enabled: boolean, userAddress: string) {
+  return Tx.contractCall("ryder-nft", "set-minter", [newMinter, types.bool(enabled)], userAddress);
 }
 
 export function getTierByTokenId(

--- a/backend-stacks/tests/ryder-mint_admin_test.ts
+++ b/backend-stacks/tests/ryder-mint_admin_test.ts
@@ -36,16 +36,16 @@ Clarinet.test({
     let block = chain.mineBlock([setMintLimit(2, deployer.address)]);
     block.receipts[0].result.expectOk().expectBool(true);
 
-    block = chain.mineBlock([claim(wallet_1.address)]);
+    block = chain.mineBlock([claim(wallet_1.address), claim(wallet_1.address)]);
     block.receipts[0].result.expectOk().expectBool(true);
-    expectNumberOfNfts(chain, 1, wallet_1.address);
+    block.receipts[0].result.expectOk().expectBool(true);
+    expectNumberOfNfts(chain, 2, wallet_1.address);
 
     block = chain.mineBlock([claim(wallet_1.address)]);
     block.receipts[0].result.expectErr().expectUint(505); // err-already-done
-    expectNumberOfNfts(chain, 1, wallet_1.address);
+    expectNumberOfNfts(chain, 2, wallet_1.address);
   },
 });
-
 
 Clarinet.test({
   name: "Ensure that admin can change payment recipient",
@@ -95,7 +95,6 @@ Clarinet.test({
   },
 });
 
-
 Clarinet.test({
   name: "Ensure that admin can add and remove new admin",
   async fn(chain: Chain, accounts: Map<string, Account>) {
@@ -143,18 +142,68 @@ Clarinet.test({
     const non_admin = accounts.get("wallet_2")!.address;
 
     let block = chain.mineBlock([
-      Tx.contractCall("ryder-nft", "set-token-uri", [types.ascii("abc")], non_admin),
-      Tx.contractCall("ryder-nft", "set-admin", [types.principal(non_admin), types.bool(true)], non_admin),
-      Tx.contractCall("ryder-mint", "set-admin", [types.principal(non_admin), types.bool(true)], non_admin),
-      Tx.contractCall("ryder-mint", "set-launched", [types.bool(true)], non_admin),
-      Tx.contractCall("ryder-mint", "set-public-mint", [types.bool(true)], non_admin),
-      Tx.contractCall("ryder-mint", "set-price-in-ustx", [types.uint(3)], non_admin),
-      Tx.contractCall("ryder-mint", "set-allow-listed-many", [types.list([types.principal(non_admin)])], non_admin),
-      Tx.contractCall("ryder-nft", "set-mint-limit", [types.uint(3)], non_admin),
-      Tx.contractCall("ryder-nft", "set-minter", [types.principal(non_admin)], non_admin),
-      Tx.contractCall("ryder-mint", "set-payment-recipient", [types.principal(non_admin)], non_admin),
+      Tx.contractCall(
+        "ryder-nft",
+        "set-token-uri",
+        [types.ascii("abc")],
+        non_admin
+      ),
+      Tx.contractCall(
+        "ryder-nft",
+        "set-admin",
+        [types.principal(non_admin), types.bool(true)],
+        non_admin
+      ),
+      Tx.contractCall(
+        "ryder-mint",
+        "set-admin",
+        [types.principal(non_admin), types.bool(true)],
+        non_admin
+      ),
+      Tx.contractCall(
+        "ryder-mint",
+        "set-launched",
+        [types.bool(true)],
+        non_admin
+      ),
+      Tx.contractCall(
+        "ryder-mint",
+        "set-public-mint",
+        [types.bool(true)],
+        non_admin
+      ),
+      Tx.contractCall(
+        "ryder-mint",
+        "set-price-in-ustx",
+        [types.uint(3)],
+        non_admin
+      ),
+      Tx.contractCall(
+        "ryder-mint",
+        "set-allow-listed-many",
+        [types.list([types.principal(non_admin)])],
+        non_admin
+      ),
+      Tx.contractCall(
+        "ryder-nft",
+        "set-mint-limit",
+        [types.uint(3)],
+        non_admin
+      ),
+      Tx.contractCall(
+        "ryder-nft",
+        "set-minter",
+        [types.principal(non_admin), types.bool(true)],
+        non_admin
+      ),
+      Tx.contractCall(
+        "ryder-mint",
+        "set-payment-recipient",
+        [types.principal(non_admin)],
+        non_admin
+      ),
       Tx.contractCall("ryder-nft", "shuffle-prepare", [], non_admin),
     ]);
-    block.receipts.map(receipt => receipt.result.expectErr().expectUint(403));
+    block.receipts.map((receipt) => receipt.result.expectErr().expectUint(403));
   },
 });

--- a/backend-stacks/tests/ryder-mint_admin_test.ts
+++ b/backend-stacks/tests/ryder-mint_admin_test.ts
@@ -44,6 +44,9 @@ Clarinet.test({
     block = chain.mineBlock([claim(wallet_1.address)]);
     block.receipts[0].result.expectErr().expectUint(505); // err-already-done
     expectNumberOfNfts(chain, 2, wallet_1.address);
+
+    block = chain.mineBlock([setMintLimit(1, deployer.address)]);
+    block.receipts[0].result.expectErr().expectUint(507); // invalid mint limit
   },
 });
 

--- a/backend-stacks/tests/ryder-nft-allow-list_test.ts
+++ b/backend-stacks/tests/ryder-nft-allow-list_test.ts
@@ -15,7 +15,7 @@ Clarinet.test({
 
     // try to mint before launch
     let block = chain.mineBlock([
-      setMinter(`'${deployer.address}.ryder-mint`, deployer.address),
+      setMinter(`'${deployer.address}.ryder-mint`, true, deployer.address),
       claim(wallet_1.address),
     ]);
     block.receipts[0].result.expectOk();
@@ -39,7 +39,7 @@ Clarinet.test({
     let block = chain.mineBlock([
       setAllowListedMany([wallet_1.address], deployer.address),
       setLaunched(true, deployer.address),
-      setMinter(`'${deployer.address}.ryder-mint`, deployer.address),
+      setMinter(`'${deployer.address}.ryder-mint`, true, deployer.address),
       claim(wallet_1.address),
       claim(wallet_1.address),
       claim(wallet_1.address),
@@ -68,7 +68,7 @@ Clarinet.test({
 
     // try to mint before launch
     let block = chain.mineBlock([
-      setMinter(`'${deployer.address}.ryder-mint`, deployer.address),
+      setMinter(`'${deployer.address}.ryder-mint`, true, deployer.address),
       claim(wallet_2.address),
     ]);
     block.receipts[0].result.expectOk();

--- a/backend-stacks/tests/ryder-nft_admin_test.ts
+++ b/backend-stacks/tests/ryder-nft_admin_test.ts
@@ -70,7 +70,7 @@ Clarinet.test({
         deployer.address
       ),
     ]);
-    block.receipts[0].result.expectErr().expectUint(507);
+    block.receipts[0].result.expectErr().expectUint(507); // err-max-mint-reached
     block.receipts[1].result.expectOk().expectBool(true);
 
     let receipt = chain.callReadOnlyFn(

--- a/backend-stacks/tests/ryder-nft_test.ts
+++ b/backend-stacks/tests/ryder-nft_test.ts
@@ -164,7 +164,7 @@ Clarinet.test({
     enabledPublicMint(chain, deployer);
 
     let block = chain.mineBlock([
-      Tx.contractCall("ryder-nft", "mint", [], wallet_1.address),
+      Tx.contractCall("ryder-nft", "mint", [types.principal(wallet_1.address)], wallet_1.address),
     ]);
     block.receipts[0].result.expectErr().expectUint(403);
   },

--- a/backend-stacks/tests/ryder-nft_test.ts
+++ b/backend-stacks/tests/ryder-nft_test.ts
@@ -63,6 +63,7 @@ Clarinet.test({
     let block = chain.mineBlock([
       claim(wallet_1.address),
       claim(wallet_1.address),
+      // 2) transfer 1 to from wallet1 to wallet2
       Tx.contractCall(
         "ryder-nft",
         "transfer-memo",
@@ -74,6 +75,7 @@ Clarinet.test({
         ],
         wallet_1.address
       ),
+      // 3) transfer 1 from wallet2 to wallet1
       Tx.contractCall(
         "ryder-nft",
         "transfer-many",
@@ -88,6 +90,7 @@ Clarinet.test({
         ],
         wallet_2.address
       ),
+      // 4) transfer 1,2 from wallet1 to wallet2 with memo
       Tx.contractCall(
         "ryder-nft",
         "transfer-memo-many",
@@ -109,12 +112,89 @@ Clarinet.test({
         ],
         wallet_1.address
       ),
+      // 5) transfer 3 from wallet1 to wallet2
+      Tx.contractCall(
+        "ryder-nft",
+        "transfer-many",
+        [
+          types.list([
+            types.tuple({
+              id: types.uint(3), // not owned id
+              sender: types.principal(wallet_1.address),
+              recipient: types.principal(wallet_2.address),
+            }),
+          ]),
+        ],
+        wallet_1.address
+      ),
+      // 6) transfer 3 from wallet1 to wallet2
+      Tx.contractCall(
+        "ryder-nft",
+        "transfer-memo-many",
+        [
+          types.list([
+            types.tuple({
+              id: types.uint(3), // not owned id
+              sender: types.principal(wallet_1.address),
+              recipient: types.principal(wallet_2.address),
+              memo: "0x6666",
+            }),
+          ]),
+        ],
+        wallet_1.address
+      ),
+      // 7) transfer 1,3 from wallet2 to wallet1
+      Tx.contractCall(
+        "ryder-nft",
+        "transfer-many",
+        [
+          types.list([
+            types.tuple({
+              id: types.uint(1),
+              sender: types.principal(wallet_2.address),
+              recipient: types.principal(wallet_1.address),
+            }),
+            types.tuple({
+              id: types.uint(3), // not owned id
+              sender: types.principal(wallet_2.address),
+              recipient: types.principal(wallet_1.address),
+            }),
+          ]),
+        ],
+        wallet_2.address
+      ),
+      // 8) transfer 2,3 from wallet2 to wallet1
+      Tx.contractCall(
+        "ryder-nft",
+        "transfer-memo-many",
+        [
+          types.list([
+            types.tuple({
+              id: types.uint(2),
+              sender: types.principal(wallet_2.address),
+              recipient: types.principal(wallet_1.address),
+              memo: "0x6666",
+            }),
+            types.tuple({
+              id: types.uint(3), // not owned id
+              sender: types.principal(wallet_2.address),
+              recipient: types.principal(wallet_1.address),
+              memo: "0x6767",
+            }),
+          ]),
+        ],
+        wallet_2.address
+      ),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
     block.receipts[2].result.expectOk().expectBool(true);
     block.receipts[3].result.expectOk().expectBool(true);
     block.receipts[4].result.expectOk().expectBool(true);
+    block.receipts[5].result.expectErr().expectUint(3);
+    block.receipts[6].result.expectErr().expectUint(3);
+    block.receipts[7].result.expectErr().expectUint(3);
+    block.receipts[8].result.expectErr().expectUint(3);
 
     block.receipts[2].events.expectNonFungibleTokenTransferEvent(
       types.uint(1),
@@ -164,7 +244,12 @@ Clarinet.test({
     enabledPublicMint(chain, deployer);
 
     let block = chain.mineBlock([
-      Tx.contractCall("ryder-nft", "mint", [types.principal(wallet_1.address)], wallet_1.address),
+      Tx.contractCall(
+        "ryder-nft",
+        "mint",
+        [types.principal(wallet_1.address)],
+        wallet_1.address
+      ),
     ]);
     block.receipts[0].result.expectErr().expectUint(403);
   },


### PR DESCRIPTION
This PR
* uses a map for minters instead of a single variable
* makes the mint-limit inclusive (e.g. mint-limit = 1000, implies that nft id 1000 is minted on stacks, 1001 is minted on eth.
* adds a test for minting with two contracts at the same time
* updates test for mint-limit 
* fixes #7 